### PR TITLE
Adaptar código para api runway

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
     APIFRAME_IMAGINE_BASE: str = "https://api.apiframe.ai/pro"
     APIFRAME_FETCH_BASE: str = "https://api.apiframe.pro"
 
+    # Runway
+    RUNWAY_API_KEY: str = "changeme"
+    RUNWAY_BASE_URL: str = "https://api.runwayml.com/v1"
+    RUNWAY_MODEL: str = "gen4_image"
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
 
 settings = Settings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ asyncpg==0.29.0
 boto3==1.35.20
 httpx==0.27.2
 python-multipart==0.0.17
+runwayml

--- a/services/image_gen_service.py
+++ b/services/image_gen_service.py
@@ -1,16 +1,18 @@
 from db.logs import logger
-from services.apiframe_service import ApiframeService
+from services.runway_service import RunwayService
 
 class ImageGenService:
     def __init__(self, provider: str = "apiframe") -> None:
         self.provider = provider
-        self.api = ApiframeService()
+        self.api = RunwayService()
 
     async def generate_from_url_and_theme(self, *, s3_url: str, aspect_ratio: str = "9:16") -> str | None:
         # Monta um prompt simples combinando URL + tema
-        prompt = f"Crie uma imagem baseada na seguinte URL: {s3_url}"
-        task_id = await self.api.imagine(prompt=prompt, aspect_ratio=aspect_ratio)
-        image_url = await self.api.monitor_progress(task_id)
+        prompt = "Crie uma imagem baseada na foto fornecida"
+        task_id = await self.api.imagine(prompt=prompt, aspect_ratio=aspect_ratio, s3_url=s3_url)
+        # Runway devolve via monitor_until_ready uma lista; pegamos a primeira
+        images = await self.api.monitor_until_ready(task_id)
+        image_url = images[0] if images else None
         if not image_url:
             logger.error("[ImageGen] Falha na geração (task_id=%s)", task_id)
             return None

--- a/services/photo_service.py
+++ b/services/photo_service.py
@@ -8,7 +8,7 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import UploadFile
 from repositories.photo_repository import PhotoRepository
-from services.apiframe_service import ApiframeService
+from services.runway_service import RunwayService
 from services.storage_service import StorageService
 from services.image_gen_service import ImageGenService
 from entities.photo import Photo
@@ -19,7 +19,7 @@ class PhotoService:
         self.repo = PhotoRepository(session)
         self.storage = StorageService()
         self.image_gen = ImageGenService()
-        self.ai = ApiframeService()
+        self.ai = RunwayService()
 
         base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         # novas molduras
@@ -82,7 +82,8 @@ class PhotoService:
             raise ValueError("Photo not found")
 
         task_id = await self.ai.imagine(prompt=prompt, aspect_ratio=aspect_ratio)
-        image_url = await self.ai.monitor_until_ready(task_id)
+        images = await self.ai.monitor_until_ready(task_id)
+        image_url = images[0] if images else None
         if not image_url:
             raise RuntimeError("Falha ao gerar imagem IA")
 

--- a/services/runway_service.py
+++ b/services/runway_service.py
@@ -1,0 +1,192 @@
+import asyncio
+import base64
+import mimetypes
+import uuid
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from db.config import settings
+from db.logs import logger
+
+# Armazena estado de tarefas em memória para acompanhamento via /progress
+_TASKS: Dict[str, Dict[str, Any]] = {}
+
+
+def _image_bytes_to_data_uri(data: bytes, content_type: Optional[str] = None) -> str:
+    ctype = content_type or "image/png"
+    b64 = base64.b64encode(data).decode("utf-8")
+    return f"data:{ctype};base64,{b64}"
+
+
+async def _download_bytes(url: str, timeout_s: int = 30) -> tuple[bytes, Optional[str]]:
+    async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=True) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        # Tenta extrair content-type do header
+        content_type = resp.headers.get("content-type")
+        return resp.content, content_type
+
+
+def _map_aspect_ratio_to_runway_ratio(ar: Optional[str]) -> str:
+    if not ar:
+        return "1024:1024"
+    val = ar.strip()
+    if val in {"1:1", "square"}:
+        return "1024:1024"
+    if val in {"16:9", "landscape"}:
+        return "1920:1080"
+    if val in {"9:16", "portrait"}:
+        return "1080:1920"
+    # Fallback simples
+    try:
+        if ":" in val:
+            a, b = val.split(":", 1)
+            a_i = int(a)
+            b_i = int(b)
+            if a_i == b_i:
+                return "1024:1024"
+            if a_i > b_i:
+                return "1920:1080"
+            return "1080:1920"
+    except Exception:
+        pass
+    return "1024:1024"
+
+
+class RunwayService:
+    def __init__(self) -> None:
+        self.api_key = settings.RUNWAY_API_KEY
+        self.model = getattr(settings, "RUNWAY_MODEL", "gen4_image")
+
+        # SDK opcional (se instalado)
+        try:
+            from runwayml import RunwayML, TaskFailedError  # type: ignore
+
+            self._sdk_cls = RunwayML
+            self._sdk_error = TaskFailedError
+        except Exception:  # pragma: no cover
+            self._sdk_cls = None
+            self._sdk_error = Exception
+
+        self._client = None
+        if self._sdk_cls is not None:
+            self._client = self._sdk_cls(api_key=self.api_key)
+
+    async def _run_generation_task(
+        self,
+        *,
+        task_id: str,
+        prompt_text: str,
+        ratio: str,
+        reference_images: Optional[List[Dict[str, str]]],
+    ) -> None:
+        # Executa geração em thread para não bloquear o loop async
+        def _worker_sync() -> Dict[str, Any]:
+            if self._client is None:
+                raise RuntimeError("SDK runwayml não instalado. Adicione a dependência 'runwayml'.")
+            # Usa SDK conforme docs
+            task = self._client.text_to_image.create(
+                model=self.model,
+                ratio=ratio,
+                prompt_text=prompt_text,
+                reference_images=reference_images or [],
+            ).wait_for_task_output()
+            return task
+
+        try:
+            _TASKS[task_id] = {"status": "RUNNING", "progress": 0}
+            result: Dict[str, Any] = await asyncio.to_thread(_worker_sync)
+
+            image_urls: List[str] = []
+            # Tenta extrair imagens do resultado
+            try:
+                output = result.get("output") or {}
+                images = output.get("images") or []
+                for img in images:
+                    url = img.get("url") or img.get("uri")
+                    if isinstance(url, str):
+                        image_urls.append(url)
+            except Exception:
+                pass
+            if not image_urls:
+                for key in ("image_urls", "images", "image_url"):
+                    val = result.get(key)
+                    if isinstance(val, list):
+                        image_urls.extend([v for v in val if isinstance(v, str)])
+                    elif isinstance(val, str):
+                        image_urls.append(val)
+
+            _TASKS[task_id] = {
+                "status": "SUCCEEDED",
+                "progress": 100,
+                "image_urls": image_urls,
+                "raw": result,
+            }
+        except Exception as e:  # pragma: no cover
+            logger.error("Runway task falhou: %s", e)
+            _TASKS[task_id] = {"status": "FAILED", "progress": 0, "error": str(e)}
+
+    async def imagine(
+        self,
+        *,
+        prompt: str,
+        aspect_ratio: Optional[str] = None,
+        s3_url: Optional[str] = None,
+        reference_images: Optional[List[Dict[str, str]]] = None,
+    ) -> str:
+        """
+        Dispara geração com Runway e retorna um task_id interno para acompanhamento.
+        - Se `s3_url` vier, baixa a imagem e inclui como referência.
+        - `reference_images`: lista [{"uri": data_uri, "tag": "ref"}, ...].
+        """
+        ratio = _map_aspect_ratio_to_runway_ratio(aspect_ratio)
+
+        refs: List[Dict[str, str]] = []
+        if reference_images:
+            refs = reference_images
+        elif s3_url:
+            try:
+                bytes_img, content_type = await _download_bytes(s3_url)
+                # Converte para data URI; Runway não aceita URL pública diretamente
+                data_uri = _image_bytes_to_data_uri(bytes_img, content_type)
+                refs.append({"uri": data_uri, "tag": "ref"})
+                # Garante que o prompt referencia a tag, caso não possua
+                if "@ref" not in prompt:
+                    prompt = f"{prompt} @ref".strip()
+            except Exception as e:
+                logger.warning("Falha ao baixar s3_url para referência: %s", e)
+
+        task_id = uuid.uuid4().hex
+        _TASKS[task_id] = {"status": "PENDING", "progress": 0}
+
+        asyncio.create_task(
+            self._run_generation_task(
+                task_id=task_id,
+                prompt_text=prompt,
+                ratio=ratio,
+                reference_images=refs,
+            )
+        )
+
+        logger.info("Runway task iniciada: %s", task_id)
+        return task_id
+
+    async def fetch_status(self, task_id: str) -> Dict[str, Any] | None:
+        return _TASKS.get(task_id)
+
+    async def monitor_until_ready(
+        self,
+        task_id: str,
+        *,
+        max_attempts: int = 300,
+        interval_s: float = 1.0,
+    ) -> List[str] | None:
+        for _ in range(max_attempts):
+            st = _TASKS.get(task_id)
+            if st and st.get("status") == "SUCCEEDED":
+                return st.get("image_urls") or []
+            if st and st.get("status") == "FAILED":
+                return []
+            await asyncio.sleep(interval_s)
+        return []


### PR DESCRIPTION
Integrate Runway API for image generation, replacing Apiframe, and adapt reference image handling to use data URIs.

The transition to Runway required adjusting how reference images are processed. Runway's API expects reference images as data URIs (base64 encoded) instead of direct public URLs. This PR implements the necessary backend logic to download images from S3 URLs or accept direct uploads, convert them to data URIs, and pass them to Runway, while maintaining the existing `task_id` and progress polling mechanism for frontend compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-33e03105-1439-493c-8e92-1fb8dde32c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33e03105-1439-493c-8e92-1fb8dde32c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

