### PR TITLE
Update backend to accept style reference URL

### DIFF
--- a/routes/ai_routes.py
+++ b/routes/ai_routes.py
@@ -21,6 +21,7 @@ async def generate(body: GenerateRequest):
             prompt=prompt,
             aspect_ratio=body.aspect_ratio,
             s3_url=(str(body.s3Url) if body.s3Url else None),
+            style_ref_url=(str(body.styleRefUrl) if getattr(body, "styleRefUrl", None) else None),
         )
         return GenerateResponse(task_id=task_id)
     except Exception as e:

--- a/schemas/ai.py
+++ b/schemas/ai.py
@@ -5,6 +5,7 @@ class GenerateRequest(BaseModel):
     # Aceita tanto prompt pronto quanto só a URL; se vierem os dois, usa `prompt`.
     prompt: Optional[str] = Field(default=None, description="Prompt final já com a URL embutida (--cref, etc.)")
     s3Url: Optional[HttpUrl] = Field(default=None, description="URL pública da imagem no S3")
+    styleRefUrl: Optional[HttpUrl] = Field(default=None, description="URL pública da imagem de referência de estilo")
     aspect_ratio: str = Field(default="9:16")
 
 class GenerateResponse(BaseModel):


### PR DESCRIPTION
Add support for `styleRefUrl` in AI generation requests to enable dual image referencing for Runway.

The frontend now sends both a user photo (`s3Url`) and a style reference image (`styleRefUrl`) to the `/ai/generate` endpoint. This PR updates the backend to accept `styleRefUrl`, download both images, convert them to data URIs, and send them as `reference_images` to the Runway API, ensuring the AI generation uses both visual inputs.

---
<a href="https://cursor.com/background-agent?bcId=bc-6df1c461-5e33-4a52-b649-8d2b6cc394fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6df1c461-5e33-4a52-b649-8d2b6cc394fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

