### PR TITLE
Fix ai photo generation endpoint

### DIFF
--- a/routes/ai_routes.py
+++ b/routes/ai_routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, UploadFile, File, Form
 from schemas.ai import GenerateRequest, GenerateResponse, ProgressResponse
 from services.runway_service import RunwayService
 
-router = APIRouter(tags=["ai"])
+router = APIRouter(prefix="/ai", tags=["ai"])
 
 @router.post("/generate", response_model=GenerateResponse)
 async def generate(body: GenerateRequest):


### PR DESCRIPTION
Add `/ai` prefix to AI routes to fix 404 Not Found errors.

The frontend was calling `POST /ai/generate`, but the backend's AI routes were registered without the `/ai` prefix, leading to a 404. This change aligns the backend routing with the frontend's API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-05f67053-d337-418f-8216-6f1d60f24781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05f67053-d337-418f-8216-6f1d60f24781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

