### PR TITLE
Update backend for new image generation request format

### DIFF
--- a/schemas/ai.py
+++ b/schemas/ai.py
@@ -11,7 +11,7 @@ class ReferenceImage(BaseModel):
 class GenerateV2Request(BaseModel):
     # Novo contrato compatível com a API do Runway
     promptText: str
-    ratio: str = Field(default="1024:1024")
+    ratio: str = Field(default="1080:1920")
     model: Optional[str] = Field(default=None, description="Override do modelo (ex.: gen4_image)")
     referenceImages: Optional[List[ReferenceImage]] = None
 

--- a/schemas/ai.py
+++ b/schemas/ai.py
@@ -1,15 +1,24 @@
 from pydantic import BaseModel, Field, HttpUrl
 from typing import Optional, List
 
-class GenerateRequest(BaseModel):
-    # Aceita tanto prompt pronto quanto só a URL; se vierem os dois, usa `prompt`.
-    prompt: Optional[str] = Field(default=None, description="Prompt final já com a URL embutida (--cref, etc.)")
-    s3Url: Optional[HttpUrl] = Field(default=None, description="URL pública da imagem no S3")
-    styleRefUrl: Optional[HttpUrl] = Field(default=None, description="URL pública da imagem de referência de estilo")
-    aspect_ratio: str = Field(default="9:16")
+
+class ReferenceImage(BaseModel):
+    # Usa string simples para suportar data URI (data:image/png;base64,...) além de URLs
+    uri: str
+    tag: str = Field(default="ref")
+
+
+class GenerateV2Request(BaseModel):
+    # Novo contrato compatível com a API do Runway
+    promptText: str
+    ratio: str = Field(default="1024:1024")
+    model: Optional[str] = Field(default=None, description="Override do modelo (ex.: gen4_image)")
+    referenceImages: Optional[List[ReferenceImage]] = None
+
 
 class GenerateResponse(BaseModel):
     task_id: str
+
 
 class ProgressResponse(BaseModel):
     progress: int

--- a/services/runway_service.py
+++ b/services/runway_service.py
@@ -158,8 +158,8 @@ class RunwayService:
             "model": model,
         }
         if reference_images:
-            # Respeita limite de até 3 imagens
-            payload["referenceImages"] = reference_images[:3]
+            # Envia exatamente como recebido (sem conversão para data URI)
+            payload["referenceImages"] = reference_images
 
         async with httpx.AsyncClient(timeout=60) as client:
             resp = await client.post(url, headers=headers, json=payload)
@@ -201,12 +201,12 @@ class RunwayService:
         # Escolhe modelo
         chosen_model = (model_override or self.model).strip()
 
-        # Ratio: se vier exact_ratio, usa direto; senão mapeia aspect_ratio simbólico
+        # Ratio: se vier exact_ratio, usa exatamente como recebido; caso contrário, mapeia e coerce
         if exact_ratio and exact_ratio.strip():
-            desired_ratio = exact_ratio.strip()
+            ratio = exact_ratio.strip()
         else:
             desired_ratio = _map_aspect_ratio_to_runway_ratio(aspect_ratio)
-        ratio = _coerce_ratio_for_model(chosen_model, desired_ratio)
+            ratio = _coerce_ratio_for_model(chosen_model, desired_ratio)
 
         refs: List[Dict[str, str]] = []
         if reference_images:


### PR DESCRIPTION
Update image generation endpoint to accept Runway API's body format, fixing frontend generation issues.

The previous backend request body for image generation did not match the format expected by the Runway API, causing the frontend image generation to fail. This PR updates the backend to accept the Runway API's body structure, including `promptText`, `ratio`, `model`, and `referenceImages`, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-906bcd5c-880c-4feb-8c22-9462828dd07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-906bcd5c-880c-4feb-8c22-9462828dd07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

